### PR TITLE
Auto-updated tests with transpec.  All tests still pass.

### DIFF
--- a/spec/active_support_spec.rb
+++ b/spec/active_support_spec.rb
@@ -11,62 +11,62 @@ describe DateTimePrecision, 'Conversions' do
   context 'when converting from Date to Time or DateTime' do
     it 'maintains precision' do
       d = Date.new(2005, 1)
-      d.precision.should == DateTimePrecision::MONTH
-      d.to_date.precision.should == DateTimePrecision::MONTH
-      d.to_datetime.precision.should == DateTimePrecision::MONTH
+      expect(d.precision).to eq(DateTimePrecision::MONTH)
+      expect(d.to_date.precision).to eq(DateTimePrecision::MONTH)
+      expect(d.to_datetime.precision).to eq(DateTimePrecision::MONTH)
     end
   end
   
   it 'loses precision when converting from DateTime or Time to Date' do
     t = Time::parse('2000-1-1 00:00:00 EST') # => Fri Dec 31 21:00:00 -0800 1999
-    t.precision.should == DateTimePrecision::SEC
-    t.to_datetime.precision.should == DateTimePrecision::SEC
-    t.to_date.precision.should == DateTimePrecision::DAY
+    expect(t.precision).to eq(DateTimePrecision::SEC)
+    expect(t.to_datetime.precision).to eq(DateTimePrecision::SEC)
+    expect(t.to_date.precision).to eq(DateTimePrecision::DAY)
   end
   
   it 'converts a date to a hash' do
     date = Date.new(1999, 10)
-    date.as_json.should == date.to_h
+    expect(date.as_json).to eq(date.to_h)
   end
   
   it 'retains precision when converting to and from JSON' do
     date = Date.new(1999, 10)
-    date.precision.should == DateTimePrecision::MONTH
+    expect(date.precision).to eq(DateTimePrecision::MONTH)
     json = ActiveSupport::JSON.encode(date)
     
     date_from_json = ActiveSupport::JSON.decode(json).to_date
-    date_from_json.precision.should == date.precision
+    expect(date_from_json.precision).to eq(date.precision)
   end
 
   context 'when formatting as a string' do
     require 'date_time_precision/format/string'
 
     it 'takes precision into account for the :long format' do
-      Date.new(2000).to_s(:long).should == "2000"
-      Date.new(2000, 8).to_s(:long).should == "August 2000"
-      Date.new(2000, 3, 9).to_s(:long).should == "March  9, 2000"
-      Date.new(nil, 5, 13).to_s(:long).should == "May 13"
-      Date.new(nil, 6).to_s(:long).should == "June"
+      expect(Date.new(2000).to_s(:long)).to eq("2000")
+      expect(Date.new(2000, 8).to_s(:long)).to eq("August 2000")
+      expect(Date.new(2000, 3, 9).to_s(:long)).to eq("March  9, 2000")
+      expect(Date.new(nil, 5, 13).to_s(:long)).to eq("May 13")
+      expect(Date.new(nil, 6).to_s(:long)).to eq("June")
 
-      DateTime.new(1800).to_s(:long).should == "1800"
-      DateTime.new(1990, 8).to_s(:long).should == "August 1990"
-      DateTime.new(-50, 3, 9).to_s(:long).should == "March 09, -0050"
-      DateTime.new(2004, 7, 8, 10).to_s(:long).should == "July 08, 2004"
-      DateTime.new(2004, 7, 8, 10, 5).to_s(:long).should == "July 08, 2004 10:05"
-      DateTime.new(nil, 5, 13).to_s(:long).should == "May 13"
-      DateTime.new(nil, 6).to_s(:long).should == "June"
+      expect(DateTime.new(1800).to_s(:long)).to eq("1800")
+      expect(DateTime.new(1990, 8).to_s(:long)).to eq("August 1990")
+      expect(DateTime.new(-50, 3, 9).to_s(:long)).to eq("March 09, -0050")
+      expect(DateTime.new(2004, 7, 8, 10).to_s(:long)).to eq("July 08, 2004")
+      expect(DateTime.new(2004, 7, 8, 10, 5).to_s(:long)).to eq("July 08, 2004 10:05")
+      expect(DateTime.new(nil, 5, 13).to_s(:long)).to eq("May 13")
+      expect(DateTime.new(nil, 6).to_s(:long)).to eq("June")
 
-      Time.mktime(1800).to_s(:long).should == "1800"
-      Time.mktime(1990, 8).to_s(:long).should == "August 1990"
+      expect(Time.mktime(1800).to_s(:long)).to eq("1800")
+      expect(Time.mktime(1990, 8).to_s(:long)).to eq("August 1990")
 
       # Every Ruby seems to have a different idea about how to format this exactly
-      Time.mktime(-50, 3, 9).to_s(:long).should match /^March 09, 0*\-0*50$/
+      expect(Time.mktime(-50, 3, 9).to_s(:long)).to match /^March 09, 0*\-0*50$/
 
-      Time.mktime(2004, 7, 8, 10).to_s(:long).should == "July 08, 2004"
-      Time.mktime(2004, 7, 8, 10, 5).to_s(:long).should == "July 08, 2004 10:05"
+      expect(Time.mktime(2004, 7, 8, 10).to_s(:long)).to eq("July 08, 2004")
+      expect(Time.mktime(2004, 7, 8, 10, 5).to_s(:long)).to eq("July 08, 2004 10:05")
 
-      Time.mktime(nil, 5, 13).to_s(:long).should == "May 13"
-      Time.mktime(nil, 6).to_s(:long).should == "June"
+      expect(Time.mktime(nil, 5, 13).to_s(:long)).to eq("May 13")
+      expect(Time.mktime(nil, 6).to_s(:long)).to eq("June")
     end
   end
 end

--- a/spec/compatibility_spec.rb
+++ b/spec/compatibility_spec.rb
@@ -32,29 +32,69 @@ describe DateTimePrecision do
       context 'when coercing a hash to a Date' do
         subject { model.date }
         
-        it { should be_a Date }
-        its(:year) { should == 1990 }
-        its(:precision) { should == DateTimePrecision::YEAR }
+        it { is_expected.to be_a Date }
+
+        describe '#year' do
+          subject { super().year }
+          it { is_expected.to eq(1990) }
+        end
+
+        describe '#precision' do
+          subject { super().precision }
+          it { is_expected.to eq(DateTimePrecision::YEAR) }
+        end
       end
       
       context 'when coercing a hash to a DateTime' do
         subject { model.datetime }
         
-        it { should be_a DateTime }
-        its(:year) { should == 1800 }
-        its(:month) { should == 2 }
-        its(:precision) { should == DateTimePrecision::MONTH }
+        it { is_expected.to be_a DateTime }
+
+        describe '#year' do
+          subject { super().year }
+          it { is_expected.to eq(1800) }
+        end
+
+        describe '#month' do
+          subject { super().month }
+          it { is_expected.to eq(2) }
+        end
+
+        describe '#precision' do
+          subject { super().precision }
+          it { is_expected.to eq(DateTimePrecision::MONTH) }
+        end
       end
       
       context 'when coercing a hash to a Time' do
         subject { model.time }
         
-        it { should be_a Time }
-        its(:year) { should == 1950 }
-        its(:month) { should == 5 }
-        its(:day) { should == 19 }
-        its(:hour) { should == 5 }
-        its(:precision) { should == DateTimePrecision::HOUR }
+        it { is_expected.to be_a Time }
+
+        describe '#year' do
+          subject { super().year }
+          it { is_expected.to eq(1950) }
+        end
+
+        describe '#month' do
+          subject { super().month }
+          it { is_expected.to eq(5) }
+        end
+
+        describe '#day' do
+          subject { super().day }
+          it { is_expected.to eq(19) }
+        end
+
+        describe '#hour' do
+          subject { super().hour }
+          it { is_expected.to eq(5) }
+        end
+
+        describe '#precision' do
+          subject { super().precision }
+          it { is_expected.to eq(DateTimePrecision::HOUR) }
+        end
       end
     end
     
@@ -66,29 +106,69 @@ describe DateTimePrecision do
       context 'when coercing a hash to a Date' do
         subject { coercer.to_date(date_hash) }
         
-        it { should be_a Date }
-        its(:year) { should == 1990 }
-        its(:precision) { should == DateTimePrecision::YEAR }
+        it { is_expected.to be_a Date }
+
+        describe '#year' do
+          subject { super().year }
+          it { is_expected.to eq(1990) }
+        end
+
+        describe '#precision' do
+          subject { super().precision }
+          it { is_expected.to eq(DateTimePrecision::YEAR) }
+        end
       end
       
       context 'when coercing a hash to a DateTime' do
         subject { coercer.to_datetime(datetime_hash) }
         
-        it { should be_a DateTime }
-        its(:year) { should == 1800 }
-        its(:month) { should == 2 }
-        its(:precision) { should == DateTimePrecision::MONTH }
+        it { is_expected.to be_a DateTime }
+
+        describe '#year' do
+          subject { super().year }
+          it { is_expected.to eq(1800) }
+        end
+
+        describe '#month' do
+          subject { super().month }
+          it { is_expected.to eq(2) }
+        end
+
+        describe '#precision' do
+          subject { super().precision }
+          it { is_expected.to eq(DateTimePrecision::MONTH) }
+        end
       end
       
       context 'when coercing a hash to a Time' do
         subject { coercer.to_time(time_hash) }
         
-        it { should be_a Time }
-        its(:year) { should == 1950 }
-        its(:month) { should == 5 }
-        its(:day) { should == 19 }
-        its(:hour) { should == 5 }
-        its(:precision) { should == DateTimePrecision::HOUR }
+        it { is_expected.to be_a Time }
+
+        describe '#year' do
+          subject { super().year }
+          it { is_expected.to eq(1950) }
+        end
+
+        describe '#month' do
+          subject { super().month }
+          it { is_expected.to eq(5) }
+        end
+
+        describe '#day' do
+          subject { super().day }
+          it { is_expected.to eq(19) }
+        end
+
+        describe '#hour' do
+          subject { super().hour }
+          it { is_expected.to eq(5) }
+        end
+
+        describe '#precision' do
+          subject { super().precision }
+          it { is_expected.to eq(DateTimePrecision::HOUR) }
+        end
       end
     end
   end

--- a/spec/date_time_precision_spec.rb
+++ b/spec/date_time_precision_spec.rb
@@ -5,166 +5,166 @@ describe DateTimePrecision do
   context 'Constructors' do
     it 'has no precision for unspecified date' do
       d = Date.new
-      d.precision.should == DateTimePrecision::NONE
-      d.year?.should be_false
+      expect(d.precision).to eq(DateTimePrecision::NONE)
+      expect(d.year?).to be_falsey
     
       dt = DateTime.new
-      dt.precision.should == DateTimePrecision::NONE
-      dt.year?.should be_false
+      expect(dt.precision).to eq(DateTimePrecision::NONE)
+      expect(dt.year?).to be_falsey
     end
   
     it 'has no precision for nil values' do
-      nil.precision.should == DateTimePrecision::NONE
+      expect(nil.precision).to eq(DateTimePrecision::NONE)
     end
   
     it 'has year precision when only year is supplied' do
       d = Date.new(1982)
-      d.precision.should == DateTimePrecision::YEAR
-      d.year?.should be_true
-      d.month?.should be_false
-      d.day?.should be_false
+      expect(d.precision).to eq(DateTimePrecision::YEAR)
+      expect(d.year?).to be_truthy
+      expect(d.month?).to be_falsey
+      expect(d.day?).to be_falsey
     end
   
     it 'has month precision when year and month are supplied' do
       d = Date.new(1982, 11)
-      d.precision.should == DateTimePrecision::MONTH
-      d.year?.should be_true
-      d.month?.should be_true
-      d.day?.should be_false
+      expect(d.precision).to eq(DateTimePrecision::MONTH)
+      expect(d.year?).to be_truthy
+      expect(d.month?).to be_truthy
+      expect(d.day?).to be_falsey
     end
   
     it 'has day precision when year, month, and day are passed in' do
       dt = DateTime.new(1987,10,19)
-      dt.precision.should == DateTimePrecision::DAY
-      dt.year?.should be_true
-      dt.month?.should be_true
-      dt.day?.should be_true
-      dt.hour?.should be_false
+      expect(dt.precision).to eq(DateTimePrecision::DAY)
+      expect(dt.year?).to be_truthy
+      expect(dt.month?).to be_truthy
+      expect(dt.day?).to be_truthy
+      expect(dt.hour?).to be_falsey
     end
   
     it 'has hour precision' do
       dt = DateTime.new(1970, 1, 2, 3)
-      dt.precision.should == DateTimePrecision::HOUR
-      dt.year?.should be_true
-      dt.month?.should be_true
-      dt.day?.should be_true
-      dt.hour?.should be_true
-      dt.min?.should be_false
+      expect(dt.precision).to eq(DateTimePrecision::HOUR)
+      expect(dt.year?).to be_truthy
+      expect(dt.month?).to be_truthy
+      expect(dt.day?).to be_truthy
+      expect(dt.hour?).to be_truthy
+      expect(dt.min?).to be_falsey
     end
     
     it 'tracks which attributes were explicitly set separately from precision' do
       [Date.new(nil, 11, 12), DateTime.new(nil, 10, 11, nil), Time.mktime(nil, 12, 13, nil, 14)].each do |d|
-        d.year?.should be_false
-        d.month?.should be_true
-        d.day?.should be_true
-        d.hour?.should be_false
-        d.min?.should be_true if d.is_a? Time
-        d.precision.should == DateTimePrecision::NONE
+        expect(d.year?).to be_falsey
+        expect(d.month?).to be_truthy
+        expect(d.day?).to be_truthy
+        expect(d.hour?).to be_falsey
+        expect(d.min?).to be_truthy if d.is_a? Time
+        expect(d.precision).to eq(DateTimePrecision::NONE)
       end
     end
   
     it 'has max precision for fully specified dates/times' do
       # Time.new is an alias for Time.now
       [Time.new, Time.now, DateTime.now, Date.today].each do |t|
-        t.precision.should == t.class::MAX_PRECISION
+        expect(t.precision).to eq(t.class::MAX_PRECISION)
       end
     end
     
     it 'accepts nil values in the constructor' do
-      Date.new(nil).precision.should == DateTimePrecision::NONE
-      Date.new(2000, nil).precision.should == DateTimePrecision::YEAR
-      DateTime.new(2000, 1, nil).precision.should == DateTimePrecision::MONTH
-      Time.mktime(2000, 1, 1, nil, nil).precision.should == DateTimePrecision::DAY
+      expect(Date.new(nil).precision).to eq(DateTimePrecision::NONE)
+      expect(Date.new(2000, nil).precision).to eq(DateTimePrecision::YEAR)
+      expect(DateTime.new(2000, 1, nil).precision).to eq(DateTimePrecision::MONTH)
+      expect(Time.mktime(2000, 1, 1, nil, nil).precision).to eq(DateTimePrecision::DAY)
     end
   end
   
   context 'Time Zones' do
     it 'should retain precision when switching to UTC' do
-      Time.mktime(2000).utc.precision.should == DateTimePrecision::YEAR
-      Time.mktime(2000).gmtime.precision.should == DateTimePrecision::YEAR
+      expect(Time.mktime(2000).utc.precision).to eq(DateTimePrecision::YEAR)
+      expect(Time.mktime(2000).gmtime.precision).to eq(DateTimePrecision::YEAR)
     end
     
     it 'should track precision when creating a date, time, or datetime in UTC' do
-      Time.utc(1945, 10).precision.should == DateTimePrecision::MONTH
-      Time.gm(1945, 10).precision.should == DateTimePrecision::MONTH
+      expect(Time.utc(1945, 10).precision).to eq(DateTimePrecision::MONTH)
+      expect(Time.gm(1945, 10).precision).to eq(DateTimePrecision::MONTH)
 
-      Date.utc(1945, 10).precision.should == DateTimePrecision::MONTH
-      DateTime.utc(1945, 10).precision.should == DateTimePrecision::MONTH
+      expect(Date.utc(1945, 10).precision).to eq(DateTimePrecision::MONTH)
+      expect(DateTime.utc(1945, 10).precision).to eq(DateTimePrecision::MONTH)
     end
     
     it 'should track precision when creating a time in the local timezone' do
-      Time.local(2004, 5, 6).precision.should == DateTimePrecision::DAY
+      expect(Time.local(2004, 5, 6).precision).to eq(DateTimePrecision::DAY)
     end
   end
 
   context 'Parsing' do
     it 'should have second/frac precision when parsing a timestamp' do
       t = Time::parse('2000-2-3 00:00:00 UTC')
-      t.precision.should == DateTimePrecision::SEC
-      t.year.should == 2000
-      t.month.should == 2
-      t.day.should == 3
+      expect(t.precision).to eq(DateTimePrecision::SEC)
+      expect(t.year).to eq(2000)
+      expect(t.month).to eq(2)
+      expect(t.day).to eq(3)
     end
   
     it 'should have minute precision when seconds are not in the timestamp' do
       dt = DateTime::parse('2000-1-1 00:00 EST') # => Sat, 01 Jan 2000 00:00:00 -0500
-      dt.precision.should == DateTimePrecision::MIN
-      dt.year.should == 2000
-      dt.day.should == 1
+      expect(dt.precision).to eq(DateTimePrecision::MIN)
+      expect(dt.year).to eq(2000)
+      expect(dt.day).to eq(1)
     end
   
     it 'should have day precision wehn parsing into a Date object' do
       d = Date::parse('2000-1-1 00:00:00 EST') # => Sat, 01 Jan 2000
-      d.precision.should == DateTimePrecision::DAY
+      expect(d.precision).to eq(DateTimePrecision::DAY)
     end
   
     it 'should have month precision when day is not in the parsed string' do
       t = Time::parse('January 2000 UTC').utc # => Sat Jan 01 00:00:00 -0800 2000
-      t.precision.should == DateTimePrecision::MONTH
-      t.year.should == 2000
-      t.month.should == 1
+      expect(t.precision).to eq(DateTimePrecision::MONTH)
+      expect(t.year).to eq(2000)
+      expect(t.month).to eq(1)
     end
   end
 
   context 'strptime' do
     it 'should have day precision when day is specified in date string' do
       d = Date.strptime('02/09/1968', '%m/%d/%Y')
-      d.precision.should == DateTimePrecision::DAY
+      expect(d.precision).to eq(DateTimePrecision::DAY)
     end
   
     it 'should have minute precision when extracting down to the minute' do
       dt = DateTime.strptime('2011-02-03 15:14:52','%Y-%m-%d %H:%M')
-      dt.precision.should == DateTimePrecision::MIN
+      expect(dt.precision).to eq(DateTimePrecision::MIN)
     end
   
     it 'should have second precision when extracting down to the second' do
       t = DateTime.strptime('2011-02-03 15:14:52','%Y-%m-%d %H:%M:%S')
-      t.precision.should == DateTimePrecision::SEC
+      expect(t.precision).to eq(DateTimePrecision::SEC)
     end
   end
 
   context 'Addition' do
     it 'should default to max precision when adding or subtracting' do
       d = Date.new
-      d.precision.should == DateTimePrecision::NONE
+      expect(d.precision).to eq(DateTimePrecision::NONE)
       d += 3
-      d.precision.should == Date::MAX_PRECISION
+      expect(d.precision).to eq(Date::MAX_PRECISION)
       d -= 2
-      d.precision.should == Date::MAX_PRECISION
+      expect(d.precision).to eq(Date::MAX_PRECISION)
     
       dt = DateTime.new
-      dt.precision.should == DateTimePrecision::NONE
+      expect(dt.precision).to eq(DateTimePrecision::NONE)
       dt += 3
-      dt.precision.should == DateTime::MAX_PRECISION
+      expect(dt.precision).to eq(DateTime::MAX_PRECISION)
       dt -= 2
-      dt.precision.should == DateTime::MAX_PRECISION
+      expect(dt.precision).to eq(DateTime::MAX_PRECISION)
     
       t = Time::parse('January 2000 UTC').utc
-      t.precision.should == DateTimePrecision::MONTH
+      expect(t.precision).to eq(DateTimePrecision::MONTH)
       t += 10
-      t.precision.should == Time::MAX_PRECISION
+      expect(t.precision).to eq(Time::MAX_PRECISION)
       t -= 8
-      t.precision.should == Time::MAX_PRECISION
+      expect(t.precision).to eq(Time::MAX_PRECISION)
     end
   end
 
@@ -172,8 +172,8 @@ describe DateTimePrecision do
     it 'should match when differing only in day precision' do
       d1 = Date.new(2001,3,2)
       d2 = Date.new(2001,3)
-      d1.partial_match?(d2).should be_true
-      d2.partial_match?(d1).should be_true
+      expect(d1.partial_match?(d2)).to be_truthy
+      expect(d2.partial_match?(d1)).to be_truthy
     end
   end
 

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -28,40 +28,40 @@ describe DateTimePrecision do
 
       [:iso8601, :xmlschema].each do |format_method|
         it 'converts a date to and from ISO 8601' do
-          date.send(format_method).should == "1989-03-11"
+          expect(date.send(format_method)).to eq("1989-03-11")
 
           @table.take(3).each do |args, format_string|
-            Date.new(*args).send(format_method).should == format_string
+            expect(Date.new(*args).send(format_method)).to eq(format_string)
 
             d = Date.send(format_method, format_string)
-            d.should == Date.new(*args)
-            d.precision.should == args.length
+            expect(d).to eq(Date.new(*args))
+            expect(d.precision).to eq(args.length)
           end
         end
         
         it 'converts a datetime to and from ISO 8601' do
-          datetime.send(format_method).should == "1989-03-11T08:30:15Z"
+          expect(datetime.send(format_method)).to eq("1989-03-11T08:30:15Z")
           
           @table.each do |args, format_string|
-            DateTime.new(*args).send(format_method).should == format_string
+            expect(DateTime.new(*args).send(format_method)).to eq(format_string)
 
             d = DateTime.send(format_method, format_string)
             constructor = args.length > 3 ? :utc : :local
-            d.should == DateTime.send(constructor, *args)
-            d.precision.should == args.length
+            expect(d).to eq(DateTime.send(constructor, *args))
+            expect(d.precision).to eq(args.length)
           end
         end
         
         it 'converts a time to ISO 8601' do
-          Time.mktime(1900).send(format_method).should == "1900"
+          expect(Time.mktime(1900).send(format_method)).to eq("1900")
 
           @table.each do |args, format_string|
-            Time.utc(*args).send(format_method).should == format_string
+            expect(Time.utc(*args).send(format_method)).to eq(format_string)
 
             t = Time.send(format_method, format_string)
             constructor = args.length > 3 ? :utc : :local
-            t.should == Time.send(constructor, *args)
-            t.precision.should == args.length
+            expect(t).to eq(Time.send(constructor, *args))
+            expect(t.precision).to eq(args.length)
           end
         end
       end
@@ -97,19 +97,19 @@ describe DateTimePrecision do
     
       context 'Converting to hash' do
         it 'should convert Date to a hash' do
-          date.to_h.should == date_hash
+          expect(date.to_h).to eq(date_hash)
         end
       
         it 'should convert DateTime to a hash' do
-          datetime.to_h.should == datetime_hash
+          expect(datetime.to_h).to eq(datetime_hash)
         end
       
         it 'should convert Time to a hash' do
-          time.to_h.should == time_hash
+          expect(time.to_h).to eq(time_hash)
         end
         
         it 'should skip year if not included' do
-          Date.new(nil, 8, 10).to_h.should == {:mon => 8, :day => 10}
+          expect(Date.new(nil, 8, 10).to_h).to eq({:mon => 8, :day => 10})
         end
       end
       
@@ -131,22 +131,22 @@ describe DateTimePrecision do
         end
         
         it 'should convert Date to a short hash' do
-          date.to_h(:short).should == short_date_hash
+          expect(date.to_h(:short)).to eq(short_date_hash)
         end
 
         it 'should convert Date to a long hash' do
-          date.to_h(:long).should == long_date_hash
+          expect(date.to_h(:long)).to eq(long_date_hash)
         end
       
         it 'should convert DateTime to a long hash' do
-          datetime.to_h(:long).should == {
+          expect(datetime.to_h(:long)).to eq({
             :year => 1989,
             :month => 3,
             :day => 11,
             :hour => 8,
             :minute => 30,
             :second => 15
-          }
+          })
         end
 
         it 'should convert Time to a short hash' do
@@ -161,75 +161,75 @@ describe DateTimePrecision do
 
           hash.merge!(:us => 1) if DateTimePrecision::MICROSECONDS_SUPPORTED
 
-          time.to_h(:short).should == hash
+          expect(time.to_h(:short)).to eq(hash)
         end
       
         it 'should convert Time to a custom hash' do
           Hash::DATE_FORMATS[:custom] = [:year, :mon, :d, :h, :min, :s]
           
-          time.to_h(:custom).should == {
+          expect(time.to_h(:custom)).to eq({
             :year => 1989,
             :mon => 3,
             :d => 11,
             :h => 8,
             :min => 30,
             :s => 15,
-          }
+          })
         end
         
         it 'should convert to the default hash format' do
           Hash::DATE_FORMATS[:default] = Hash::DATE_FORMATS[:short]
-          date.to_h(:short).should == short_date_hash
+          expect(date.to_h(:short)).to eq(short_date_hash)
           Hash::DATE_FORMATS[:default] = Hash::DATE_FORMATS[:ruby]
         end
         
         it 'should only include fields that were set' do
-          Date.new(nil, 3, 8).to_h.should == {:mon => 3, :day => 8}
-          DateTime.new(nil, 5, 6, nil, 7).to_h.should == {:mon => 5, :day => 6, :min => 7}
-          Time.mktime(nil, 1, nil, 9, nil, 10).to_h.should == {:mon => 1, :hour => 9, :sec => 10}
+          expect(Date.new(nil, 3, 8).to_h).to eq({:mon => 3, :day => 8})
+          expect(DateTime.new(nil, 5, 6, nil, 7).to_h).to eq({:mon => 5, :day => 6, :min => 7})
+          expect(Time.mktime(nil, 1, nil, 9, nil, 10).to_h).to eq({:mon => 1, :hour => 9, :sec => 10})
         end
       end
   
       context 'Converting from hash' do
         it 'converts a hash to a Date' do
-          date_hash.to_date.should == date
+          expect(date_hash.to_date).to eq(date)
         end
     
         it 'converts a hash to a DateTime' do
-          datetime_hash.to_datetime.should == datetime
+          expect(datetime_hash.to_datetime).to eq(datetime)
         end
     
         it 'converts a hash to a Time' do
-          time_hash.to_time.should == time
+          expect(time_hash.to_time).to eq(time)
         end
       
         it 'accepts flexible keys' do
-          {
+          expect({
             :y => 1989,
             :m => 3,
             :d => 11
-          }.to_date.should == date
+          }.to_date).to eq(date)
         
-          {
+          expect({
             :year => 1989,
             :month => 3,
             :day => 11
-          }.to_date.should == date
+          }.to_date).to eq(date)
         end
         
         [:date, :datetime, :time].each do |klass|
           it "accepts month and day without year when converting to a #{klass}" do
             date = { :month => 5, :day => 18, :min => 48 }.send("to_#{klass}")
-            date.year?.should be_false
-            date.month?.should be_true
-            date.month.should == 5
-            date.day?.should be_true
-            date.day.should == 18
-            date.hour?.should be_false
+            expect(date.year?).to be_falsey
+            expect(date.month?).to be_truthy
+            expect(date.month).to eq(5)
+            expect(date.day?).to be_truthy
+            expect(date.day).to eq(18)
+            expect(date.hour?).to be_falsey
             
             unless klass == :date
-              date.min?.should be_true
-              date.min.should == 48
+              expect(date.min?).to be_truthy
+              expect(date.min).to eq(48)
             end
           end
         end
@@ -241,18 +241,18 @@ describe DateTimePrecision do
       require 'json'
     
       it 'should convert a date to a JSON hash' do
-        date.as_json.should == date.to_h
-        date.to_json.should == date.to_h.to_json
+        expect(date.as_json).to eq(date.to_h)
+        expect(date.to_json).to eq(date.to_h.to_json)
       end
     
       it 'should convert a datetime to a JSON hash' do
-        datetime.as_json.should == datetime.to_h
-        datetime.to_json.should == datetime.to_h.to_json
+        expect(datetime.as_json).to eq(datetime.to_h)
+        expect(datetime.to_json).to eq(datetime.to_h.to_json)
       end
       
       it 'should convert a time to a JSON hash' do
-        time.as_json.should == time.to_h
-        time.to_json.should == time.to_h.to_json
+        expect(time.as_json).to eq(time.to_h)
+        expect(time.to_json).to eq(time.to_h.to_json)
       end
     end
     


### PR DESCRIPTION
I'm trying to add some functionality that I'd like to **date_time_precision**, and I was having a problem that the tests use depreciated syntax, and some of them are depreciated enough that they fail.

On the [rspec site](https://www.relishapp.com/rspec/rspec-expectations/docs/syntax-configuration), at , they recommend using [Transpec](http://yujinakayama.me/transpec/) to update the syntax. 

Running it appears to have updated the tests to the new syntax, and solves my problems with the tests.

Dunno if this is something you're interested in, but figured I'd send it your way and see if it helps.

The library is super-helpful, by the way.  Thank you.
